### PR TITLE
Added options: '-l', '--local-only' and '-a', '--listen-address [host]'.

### DIFF
--- a/bin/adsf
+++ b/bin/adsf
@@ -11,7 +11,8 @@ options = {
   :handler            => nil,
   :port               => 3000,
   :index_filenames => %w( index.html ),
-  :root               => '.'
+  :root               => '.',
+  :host               => '0.0.0.0',
 }
 OptionParser.new do |opts|
   opts.banner = "Usage: adsf [options]"
@@ -44,6 +45,16 @@ OptionParser.new do |opts|
   opts.on('-r', '--root [root]', 'Specify the web root to use') do |o|
     options[:root] = o
   end
+
+  # host
+  opts.on('-l', '--local-only', 'Only listen to requests from localhost (short for "-a localhost")') do
+    options[:host] = 'localhost'
+  end
+
+  # host
+  opts.on('-a', '--listen-address [host]', 'Specify the address to listen to') do |o|
+    options[:host] = o
+  end
 end.parse!
 
 # Find handler
@@ -73,4 +84,4 @@ end.to_app
 end
 
 # Run
-handler.run(app, :Port => options[:port])
+handler.run(app, :Port => options[:port], :Host => options[:host])


### PR DESCRIPTION
Here's your pull request, as requested.

You might also want to update the link to the source code from stoneship.org/software/adsf/ to point at GitHub.
