### PR TITLE
Disable Flash

### DIFF
--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -63,7 +63,7 @@ module Adsf
 
         if is_live
           require 'adsf/live'
-          use ::Rack::LiveReload, source: :vendored
+          use ::Rack::LiveReload, no_swf: true, source: :vendored
         end
 
         run ::Rack::File.new(root)


### PR DESCRIPTION
Modern browsers don’t support Flash anymore, so disabling Flash in `Rack::LiveReload` makes sense.

(No tests needed for this change, as Flash wasn’t really used before anyway.)

CC @Fjan

Closes #24.