### PR TITLE
Add charset=utf-8 to HTML responses

### DIFF
--- a/adsf/adsf.gemspec
+++ b/adsf/adsf.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
   s.add_runtime_dependency('rack', '>= 1.0.0', '< 3.0.0')
+  s.add_runtime_dependency('rack-contrib', '~> 2.3')
 
   s.files                 = ['NEWS.md', 'README.md'] + Dir['bin/**/*'] + Dir['lib/**/*.rb']
   s.executables           = ['adsf']

--- a/adsf/lib/adsf.rb
+++ b/adsf/lib/adsf.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack'
+require 'rack/contrib'
 
 module Adsf
 end

--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -66,6 +66,12 @@ module Adsf
           use ::Rack::LiveReload, no_swf: true, source: :vendored
         end
 
+        use ::Rack::ResponseHeaders do |headers|
+          if headers['Content-Type'] == 'text/html'
+            headers['Content-Type'] = 'text/html; charset=utf-8'
+          end
+        end
+
         run ::Rack::File.new(root)
       end.to_app
     end

--- a/adsf/test/test_server.rb
+++ b/adsf/test/test_server.rb
@@ -116,7 +116,7 @@ class Adsf::Test::Server < MiniTest::Test
   def test_content_type_html
     run_server do
       response = Net::HTTP.get_response('127.0.0.1', '/sample.html', 50_386)
-      assert_equal 'text/html', response['Content-Type']
+      assert_equal 'text/html; charset=utf-8', response['Content-Type']
     end
   end
 


### PR DESCRIPTION
### Detailed description

This changes the `Content-Type` for HTML from `text/html` to `text/html; charset=utf-8`. This should be correct for the vast majority of cases.

Future work could include using [rchardet](https://github.com/jmhodges/rchardet).

### To do

- [x] Tests

### Related issues

Fixes #19.
