### PR TITLE
Support Rack 3.0

### DIFF
--- a/adsf/adsf.gemspec
+++ b/adsf/adsf.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.email                 = 'denis.defreyne@stoneship.org'
 
   s.required_ruby_version = '>= 2.5'
-  s.add_runtime_dependency('rack', '>= 1.0.0', '< 3.0.0')
+  s.add_runtime_dependency('rack', '>= 1.0.0', '< 4.0.0')
+  s.add_runtime_dependency('rackup', '~> 2.1')
 
   s.files                 = ['NEWS.md', 'README.md'] + Dir['bin/**/*'] + Dir['lib/**/*.rb']
   s.executables           = ['adsf']

--- a/adsf/lib/adsf.rb
+++ b/adsf/lib/adsf.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack'
+require 'rackup'
 
 module Adsf
 end

--- a/adsf/lib/adsf/rack/caching.rb
+++ b/adsf/lib/adsf/rack/caching.rb
@@ -11,7 +11,7 @@ module Adsf::Rack
 
       new_headers =
         headers.merge(
-          'Cache-Control' => 'max-age=0, stale-if-error=0',
+          'cache-control' => 'max-age=0, stale-if-error=0',
         )
 
       [status, new_headers, body]

--- a/adsf/lib/adsf/rack/cors.rb
+++ b/adsf/lib/adsf/rack/cors.rb
@@ -11,8 +11,8 @@ module Adsf::Rack
 
       new_headers =
         headers.merge(
-          'Access-Control-Allow-Origin' => '*',
-          'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Accept, Range',
+          'access-control-allow-origin' => '*',
+          'access-control-allow-headers' => 'Origin, X-Requested-With, Content-Type, Accept, Range',
         )
 
       [status, new_headers, body]

--- a/adsf/lib/adsf/rack/index_file_finder.rb
+++ b/adsf/lib/adsf/rack/index_file_finder.rb
@@ -18,7 +18,7 @@ module Adsf::Rack
         new_path_info = env['PATH_INFO'] + '/'
         return [
           302,
-          { 'Location' => new_path_info, 'Content-Type' => 'text/html' },
+          { 'location' => new_path_info, 'content-type' => 'text/html' },
           ["Redirecting you to #{new_path_info}&hellip;"],
         ]
       end

--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -72,9 +72,9 @@ module Adsf
 
     def build_handler
       if @handler
-        ::Rack::Handler.get(@handler)
+        ::Rackup::Handler.get(@handler)
       else
-        ::Rack::Handler.default
+        ::Rackup::Handler.default
       end
     end
   end


### PR DESCRIPTION
### Detailed description

Allows using Rack 3.0. This comes with a few changes (see the [Rack 3.0 upgrade guide](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md)):

* `Rack::Handler` is moved to the new `rackup` gem and is now `Rackup::Handler`
* header names must be lowercase

### To do

- [x] Tests

### Related issues

n/a