### PR TITLE
Use Rack::Files, not Rack::File

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `Adsf::Rack::IndexFileFinder` middleware makes Rack load an index file (e.g.
 
 ```ruby
 use Adsf::Rack::IndexFileFinder, root: 'public'
-run Rack::File.new('public')
+run Rack::Files.new('public')
 ```
 
 It takes the following options:
@@ -48,12 +48,12 @@ It takes the following options:
   use Adsf::Rack::IndexFileFinder,
   	root: 'public',
   	index_filenames: %w[index.html index.xhtml]
-  run Rack::File.new('public')
+  run Rack::Files.new('public')
   ```
 
 **Why not use `Rack::Static`?** Rack comes with `Rack::Static`, whose purpose is similar to, but not the same as, `Adsf::Rack::IndexFileFinder`. In particular:
 
-- `Adsf::Rack::IndexFileFinder` does not serve files, unlike `Rack::Static`. `IndexFileFinder` only rewrites the incoming request and passes it on (usually to `Rack::File`).
+- `Adsf::Rack::IndexFileFinder` does not serve files, unlike `Rack::Static`. `IndexFileFinder` only rewrites the incoming request and passes it on (usually to `Rack::Files`).
 
 - `Adsf::Rack::IndexFileFinder` supports multiple index files, while `Rack::Static` only supports one (you could have multiple `Rack::Static` middlewares, one for each index filenames, though).
 

--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -66,7 +66,7 @@ module Adsf
           use ::Rack::LiveReload, no_swf: true, source: :vendored
         end
 
-        run ::Rack::File.new(root)
+        run ::Rack::Files.new(root)
       end.to_app
     end
 

--- a/adsf/test/rack/test_index_file_finder.rb
+++ b/adsf/test/rack/test_index_file_finder.rb
@@ -14,7 +14,7 @@ class Adsf::Test::Rack::IndexFileFinder < Minitest::Test
   end
 
   def stub_app
-    Rack::File.new('.')
+    Rack::Files.new('.')
   end
 
   def test_get_file


### PR DESCRIPTION
### Detailed description

The latter is deprecated.

### To do

n/a

### Related issues

Fixes #30.
