### PR TITLE
Fix gemspec to include vendored livereload

### DIFF
--- a/adsf-live/adsf-live.gemspec
+++ b/adsf-live/adsf-live.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('eventmachine', '~> 1.2')
   s.add_dependency('listen', '~> 3.0')
 
-  s.files                 = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb']
+  s.files                 = ['NEWS.md', 'README.md'] + Dir['lib/**/*.rb'] + ['vendor/livereload.js']
   s.require_path          = 'lib'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/adsf-live/adsf-live.manifest
+++ b/adsf-live/adsf-live.manifest
@@ -6,3 +6,4 @@ lib/adsf/live/version.rb
 lib/adsf/live/rack_livereload.rb
 lib/adsf/live/watcher.rb
 lib/adsf/live/web_socket_server.rb
+vendor/livereload.js


### PR DESCRIPTION
### Detailed description

We forgot to update the gemspec in https://github.com/denisdefreyne/adsf/commit/e2b15cd006b18d2cdeef682867dfc984f692bbf3 this should fix that

### Related issues

https://github.com/denisdefreyne/adsf/issues/40