### PR TITLE
[Pitch] Manual reload

### DIFF
--- a/adsf-live/lib/adsf/live/watcher.rb
+++ b/adsf-live/lib/adsf/live/watcher.rb
@@ -3,22 +3,27 @@
 module Adsf
   module Live
     class Watcher
-      def initialize(root_dir:)
+      def initialize(root_dir:, watch_files: true)
         unless Pathname.new(root_dir).absolute?
           raise ArgumentError, 'Watcher#initialize: The root_path argument must be an absolute path'
         end
 
         @root_dir = root_dir
+        @watch_files = watch_files
       end
 
       def start
         @server = start_server
-        @listener = start_listener(@server)
+        @listener = start_listener(@server) if @watch_files
       end
 
       def stop
         @listener&.stop
         @server&.stop
+      end
+
+      def reload(paths)
+        @server.reload(paths)
       end
 
       def start_server

--- a/adsf-live/vendor/livereload.js
+++ b/adsf-live/vendor/livereload.js
@@ -491,20 +491,20 @@
                     }
                 }
                 if (options.liveCSS) {
-                    if (path.match(/\.css$/i)) {
+                    if (path && path.match(/\.css$/i)) {
                         if (this.reloadStylesheet(path)) {
                             return;
                         }
                     }
                 }
                 if (options.liveImg) {
-                    if (path.match(/\.(jpe?g|png|gif)$/i)) {
+                    if (path && path.match(/\.(jpe?g|png|gif)$/i)) {
                         this.reloadImages(path);
                         return;
                     }
                 }
                 var current_path= document.location.pathname // Only reload the page if we need to
-                if (path === current_path || path === current_path+'index.html')
+                if (path === null || path === current_path || path === current_path+'index.html')
                     return this.reloadPage();
             };
 

--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -43,12 +43,20 @@ module Adsf
       @q << true
     end
 
+    def live_reload(paths)
+      @watcher.reload(paths)
+    end
+
     private
 
     def start_watcher
       require 'adsf/live'
 
-      ::Adsf::Live::Watcher.new(root_dir: File.absolute_path(@root)).tap(&:start)
+      @watcher = ::Adsf::Live::Watcher.new(
+        root_dir: File.absolute_path(@root),
+        watch_files: @live != :manual
+      )
+      @watcher.start
     end
 
     def wait_for_stop_async(server)

--- a/adsf/lib/adsf/server.rb
+++ b/adsf/lib/adsf/server.rb
@@ -43,7 +43,7 @@ module Adsf
       @q << true
     end
 
-    def live_reload(paths)
+    def live_reload(paths = [nil])  # nil tells client JS to match any path
       @watcher.reload(paths)
     end
 


### PR DESCRIPTION
### Detailed description

This is a _possible_ feature. I’m opening the PR to see (1) whether the general idea would be acceptable for the project, and (2) if so, what adjustments this specific design needs.

This PR contains a working implementation, but no docs or tests yet (pending feedback).

#### The problem

I’m using adsf for a custom static site generator, which does not have an incremental rebuild: it always regenerates _all_ the output files when _any_ file changes. That mixes poorly with adsf-live, which watches and reports every _individual_ file change, causing several problems:

- Using `Listen` with many files at once has performance costs.
- Sending the paths for every output file in the whole site on every change has performance costs.
  
  In my project, this plus the previous item make rebuilding on change **slower by a factor of 2-3x** than a clean build (before the watcher has started). Furthermore, it’s unclear why, but this performance penalty appears to increase with multiple rebuilds. Reporting individual file changes is supposed to improve performance, but for me has the opposite effect.
- Change notifications to the client start before the output directory is fully written, frequently causing multiple client refreshes for a single rebuild.
- Files that are written incrementally sometimes get refreshed by the browser before fully written, resulting in (for example) pages loaded with only half the stylesheet, forcing a manual refresh (and thus defeating the whole purpose of adsf-live).

These problems all boil down to three causes:

- Watching so many files is a problem.
- Sending paths of so many individual files to the browser is a problem.
- Triggering refresh on “individual file changed!” instead of “build complete!” is a problem.

#### The proposal

This PR implements three related features:

1. The Adsf server now supports a “manual” live reload mode, enabled like this:

  ```ruby
  server = Adsf::Server.new(live: :manual, root: …)
  ```

  In manual mode, adsf does not watch for file changes.

2. `Adsf::Server` now has a `live_reload` method, which optionally accepts an array of paths, but by default signals that _all_ files need to be reloaded:

  ```ruby
  server.live_reload  # reload everything
  server.live_reload(["/some/changed/file", "/other/changed/file"])
  ```

3. In the socket server protocol, passing `null` for `path` now signals that the browser should _always_ reload, regardless of the currently displayed file.

(This would be a Ruby-API-only feature; I don’t think it’s urgent for the CLI. The CLI _could_ support it by trigger reload on stdin, or accept a UNIX pipe argument, or watch on specific reload file or something…but that feels like a separate feature request that needs a use case first.)

What do you think? Is this a feature idea you’d accept? If so, beyond docs and tests (obviously), what PR changes would you like to see? Would you prefer a different design? (I’m particularly uncertain about the API shape for (1) and the change to the protocol in (3).)

### To do

- [ ] Tests
- [ ] Documentation
- [ ] Feature flags
- [ ] …

### Related issues

(Add issue IDs for related issues here.)
