### PR TITLE
Prevent sending and parsing livereload.js on every page load

### DIFF
--- a/adsf-live/lib/adsf/live/rack_livereload.rb
+++ b/adsf-live/lib/adsf/live/rack_livereload.rb
@@ -48,8 +48,8 @@ module Rack
     def deliver_file(file)
       [
         200,
-       { 'content-type' => 'text/javascript', 'content-length' => ::File.size(file).to_s, 'cache-control' => 'public, max-age=3600, immutable' },
-       [::File.read(file)]
+        { 'content-type' => 'text/javascript', 'content-length' => ::File.size(file).to_s, 'cache-control' => 'public, max-age=3600, immutable' },
+        [::File.read(file)],
       ]
     end
 

--- a/adsf-live/lib/adsf/live/rack_livereload.rb
+++ b/adsf-live/lib/adsf/live/rack_livereload.rb
@@ -46,7 +46,11 @@ module Rack
     private
 
     def deliver_file(file)
-      [200, { 'content-type' => 'text/javascript', 'content-length' => ::File.size(file).to_s }, [::File.read(file)]]
+      [
+        200,
+       { 'content-type' => 'text/javascript', 'content-length' => ::File.size(file).to_s, 'cache-control' => 'public, max-age=3600, immutable' },
+       [::File.read(file)]
+      ]
     end
 
     def template
@@ -55,7 +59,7 @@ module Rack
           RACK_LIVERELOAD_PORT = #{@options[:live_reload_port] || LIVERELOAD_PORT}
           RACK_LIVERELOAD_SCHEME = "#{@options[:live_reload_scheme] || LIVERELOAD_SCHEME}"
         </script>
-        <script src="#{livereload_source}?host=#{host_to_use}"></script>
+        <script defer src="#{livereload_source}?host=#{host_to_use}"></script>
       HTML
     end
 

--- a/adsf/lib/adsf/rack/caching.rb
+++ b/adsf/lib/adsf/rack/caching.rb
@@ -9,12 +9,9 @@ module Adsf::Rack
     def call(env)
       status, headers, body = *@app.call(env)
 
-      new_headers =
-        headers.merge(
-          'cache-control' => 'max-age=0, stale-if-error=0',
-        )
+      headers['cache-control'] ||= 'max-age=0, stale-if-error=0'
 
-      [status, new_headers, body]
+      [status, headers, body]
     end
   end
 end


### PR DESCRIPTION
This PR adds a Cache-Control header to the response that sends livereload.js. Currently no Cache-Control header is set, so the browser re-downloads the entire 43KB on every request. Also, because the JS file is in the header this keeps the browser from  rendering anything on the page until the 43KB has been read and parsed on each request.

### Detailed description

This PR does three small things:
- It adds `Cache-Control: public, max-age=3600, immutable` to the livereload.js file
- It ensures the `Adsf::Rack::Caching` middleware respects Cache-Control headers for responses that have one
- It adds a `defer` attribute on the script tag, to ensure the script does not block rendering

The cache control header is covered by existing tests, tests pass. 

